### PR TITLE
Feat/biowriter: Scalability and Extended Writing Ability

### DIFF
--- a/bfio/backends.py
+++ b/bfio/backends.py
@@ -843,6 +843,10 @@ class PythonWriter(bfio.base_classes.AbstractWriter):
 
     logger = logging.getLogger("bfio.backends.PythonWriter")
 
+    def __init__(self, frontend):
+
+        super().__init__(frontend)
+
     def _pack(self, fmt, *val):
         if fmt[0] not in "<>":
             fmt = self._writer.tiff.byteorder + fmt

--- a/bfio/backends.py
+++ b/bfio/backends.py
@@ -688,7 +688,6 @@ class TiffIFDHeader:
                 for size in self.databyteoffsets:
                     self.ifd.write(self._pack(offsetformat, size))
             else:
-                print(self.databyteoffsets)
                 self.ifd.write(self._pack(offsetformat, self.databyteoffsets[0]))
 
             # update strip/tile bytecounts
@@ -706,7 +705,6 @@ class TiffIFDHeader:
     def set_next_ifd(self, pos):
 
         self.ifd.seek(self.ifdoffset)
-        print(f"Next page position: {pos}")
         self.ifd.write(self._pack(self.offsetformat, pos))
         self.ifd.seek(self.ifdsize)
 
@@ -769,9 +767,6 @@ class TiffIFDHeaders(object):
         return self.headers[index]
 
     def _generate_page(self, index):
-
-        print(f"Page #{index}")
-        print(f"Page start: {self._ifdpos}")
 
         tagnoformat = self.tiff.tagnoformat
         offsetformat = self.tiff.offsetformat
@@ -1136,8 +1131,6 @@ class PythonWriter(bfio.base_classes.AbstractWriter):
         skip = (16 - (headers_size % 16)) % 16
         fh.seek(skip, 1)
         self._dataoffset = headers_size + skip
-
-        print(f"dataoffset: {self._dataoffset}")
 
     def iter_tiles(self, data, tile, tiles):
         """Return iterator over tiles in data array of normalized shape."""

--- a/bfio/base_classes.py
+++ b/bfio/base_classes.py
@@ -577,9 +577,8 @@ class BioBase(object, metaclass=abc.ABCMeta):
 
     @samples_per_pixel.setter
     def samples_per_pixel(self, samples_per_pixel: int):
-        self._metadata.images[0].pixels.channels[
-            0
-        ].samples_per_pixel = samples_per_pixel
+        for channel in self._metadata.images[0].pixels.channels:
+            channel.samples_per_pixel = samples_per_pixel
 
     @property
     def spp(self):

--- a/bfio/bfio.py
+++ b/bfio/bfio.py
@@ -1002,17 +1002,17 @@ class BioWriter(BioBase):
                 if value.shape[i] != getattr(self, d):
                     raise IndexError(
                         "Shape of image {} does not match the ".format(value.shape)
-                        + "save dimensions {}.".format(self.shape)
+                        + "save dimensions {}.".format(ind)
                     )
             elif d in "YXZ" and ind[d][1] - ind[d][0] != value.shape[i]:
                 raise IndexError(
                     "Shape of image {} does not match the ".format(value.shape)
-                    + "save dimensions {}.".format((s[1] - s[0] for s in ind.values()))
+                    + "save dimensions {}.".format(ind)
                 )
             elif d in "CT" and len(ind[d]) != value.shape[i]:
                 raise IndexError(
                     "Shape of image {} does not match the ".format(value.shape)
-                    + "save dimensions {}.".format((s[1] - s[0] for s in ind.values()))
+                    + "save dimensions {}.".format(ind)
                 )
             elif d in "YXZ":
                 ind[d] = ind[d][0]

--- a/bfio/bfio.py
+++ b/bfio/bfio.py
@@ -1002,9 +1002,7 @@ class BioWriter(BioBase):
                 if value.shape[i] != getattr(self, d):
                     raise IndexError(
                         "Shape of image {} does not match the ".format(value.shape)
-                        + "save dimensions {}.".format(
-                            list(s[1] - s[0] for s in ind.values())
-                        )
+                        + "save dimensions {}.".format(self.shape)
                     )
             elif d in "YXZ" and ind[d][1] - ind[d][0] != value.shape[i]:
                 raise IndexError(
@@ -1030,18 +1028,30 @@ class BioWriter(BioBase):
         assert (
             not self._read_only
         ), "The image has started to be written. To modify the xml again, reinitialize."
-        omexml = ome_types.model.OME.construct()
-        omexml.images[0].name = Path(self._file_path).name
-        p = omexml.image[0].pixels
-
-        assert isinstance(p, ome_types.model.Pixels)
-
-        for d in "xyzct":
-            setattr(p, "size_{}".format(d), 1)
-
-        p.dimension_order = ome_types.model.Pixels.dimension_order.XYZCT
-        p.type = ome_types.model.simple_types.UINT8
-        p.channel_count = 1
+        omexml = ome_types.model.OME()
+        omexml.images.append(
+            ome_types.model.Image(
+                id="Image:0",
+                pixels=ome_types.model.Pixels(
+                    id="Pixels:0",
+                    dimension_order="XYZCT",
+                    big_endian=False,
+                    size_c=1,
+                    size_z=1,
+                    size_t=1,
+                    size_x=1,
+                    size_y=1,
+                    channels=[
+                        ome_types.model.Channel(
+                            id="Channel:0",
+                            samples_per_pixel=1,
+                        )
+                    ],
+                    type=ome_types.model.simple_types.PixelType.UINT8,
+                    tiff_data_blocks=[ome_types.model.TiffData()],
+                ),
+            )
+        )
 
         return omexml
 

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     ],
     python_requires=">=3.6",
     install_requires=[
-        "tifffile>=2022.3.16",
+        "tifffile>=2021.8.30",
         "imagecodecs>=2021.2.26",
         "numpy>=1.20.1",
         "ome-types>=0.2.10",

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -1,0 +1,126 @@
+import unittest
+import requests, io, pathlib, shutil, logging, sys
+import bfio
+import numpy as np
+
+TEST_IMAGES = {
+    # "1884807.ome.zarr": "https://s3.embassy.ebi.ac.uk/idr/zarr/v0.1/1884807.zarr/",
+    "Plate1-Blue-A-12-Scene-3-P3-F2-03.czi": "https://downloads.openmicroscopy.org/images/Zeiss-CZI/idr0011/Plate1-Blue-A_TS-Stinger/Plate1-Blue-A-12-Scene-3-P3-F2-03.czi",
+    "0.tif": "https://osf.io/j6aer/download",
+    "img_r001_c001.ome.tif": "https://github.com/usnistgov/WIPP/raw/master/data/PyramidBuilding/inputCollection/img_r001_c001.ome.tif",
+    "Leica-1.scn": "https://downloads.openmicroscopy.org/images/Leica-SCN/openslide/Leica-1/Leica-1.scn",
+}
+
+TEST_DIR = pathlib.Path(__file__).with_name("data")
+
+logging.basicConfig(
+    format="%(asctime)s - %(name)-8s - %(levelname)-8s - %(message)s",
+    datefmt="%d-%b-%y %H:%M:%S",
+)
+logger = logging.getLogger("bfio.test")
+
+if "-v" in sys.argv:
+    logger.setLevel(logging.INFO)
+
+
+def setUpModule():
+
+    """Download images for testing"""
+    TEST_DIR.mkdir(exist_ok=True)
+
+    for file, url in TEST_IMAGES.items():
+        logger.info(f"setup - Downloading: {file}")
+
+        if not file.endswith(".ome.zarr"):
+            if TEST_DIR.joinpath(file).exists():
+                continue
+
+            r = requests.get(url)
+
+            with open(TEST_DIR.joinpath(file), "wb") as fw:
+
+                fw.write(r.content)
+        else:
+
+            base_path = TEST_DIR.joinpath(file)
+            base_path.mkdir()
+            base_path.joinpath("0").mkdir()
+
+            units = [
+                ".zattrs",
+                ".zgroup",
+                "0/.zarray",
+                "0/0.0.0.0.0",
+                "0/0.1.0.0.0",
+                "0/0.2.0.0.0",
+            ]
+
+            for u in units:
+
+                if base_path.joinpath(u).exists():
+                    continue
+
+                with open(base_path.joinpath(u), "wb") as fw:
+
+                    fw.write(requests.get(url + u).content)
+
+
+class TestOmeTiffWrite(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        """Load the czi image, and save as a npy file for further testing."""
+
+        if TEST_DIR.joinpath("4d_array.npy").exists():
+            return
+
+        with bfio.BioReader(
+            TEST_DIR.joinpath("Plate1-Blue-A-12-Scene-3-P3-F2-03.czi")
+        ) as br:
+
+            np.save(TEST_DIR.joinpath("4d_array.npy"), br[:])
+
+    def test_write_python(self):
+
+        with bfio.BioWriter("4d_array.ome.tif") as bw:
+
+            image = np.load(TEST_DIR.joinpath("4d_array.npy"))
+
+            bw.shape = image.shape[:3]
+            bw.dtype = image.dtype
+
+            bw[:] = image[:, :, :, 0]
+
+        with bfio.BioReader("4d_array.ome.tif", backend="python") as br:
+
+            reconstructed = br[:]
+
+        assert np.array_equal(image[..., 0], reconstructed)
+
+    @unittest.expectedFailure
+    def test_write_channels_python(self):
+        # Cannot write an image with channel information using python backend
+
+        with bfio.BioWriter("4d_array.ome.tif") as bw:
+
+            image = np.load(TEST_DIR.joinpath("4d_array.npy"))
+
+            bw.shape = image.shape
+            bw.dtype = image.dtype
+
+    def test_write_java(self):
+        # Cannot write an image with channel information using python backend
+
+        with bfio.BioWriter("4d_array.ome.tif", backend="java") as bw:
+
+            image = np.load(TEST_DIR.joinpath("4d_array.npy"))
+
+            bw.shape = image.shape
+            bw.dtype = image.dtype
+
+            bw[:] = image
+
+        with bfio.BioReader("4d_array.ome.tif", backend="python") as br:
+
+            reconstructed = br[:]
+
+        assert np.array_equal(image, reconstructed)


### PR DESCRIPTION
This PR adds in a number of changes to how the BioWriter operates. The major changes are:

1. Channel and timepoint data can now be saved
2. Implements a scattered tile approach to saving data, permitting scalable image writes

The scattered tile approach to saving data has all IFD header information written at the beginning of the file, leaving the remainder of the file to be written as new tiles are requested to be saved. Previously, it was only permitted to save images one z-plane at a time, and z-planes could not be saved out of order. This had to do primarily with IFDs being written as follows:
[IFDHeader1 image_tiles1] [IFD_Header2 image_tiles2] ...

Since compression is always on, the size of image_tiles could not be known beforehand, so the offsets between IFDs could not be known. However, now data is stored as follows
IFD_Header1 IFD_Header2 ... image_tiles

This allows planes and tiles to be written in arbitrary order, including out of order. This also makes it more convenient to expand the capability of the BioWriter to support z-slices, channels, and timepoints for arbitrarily sized data. It also allows us to perform near full threaded writing of data across n-dimensions, whereas prior threaded writes could only occur along a plane. This has led to a pretty significant improvement of writing performance for images with many ZCT planes. Writing is now less than 2x slower than reading (ignoring OME XML parsing, see below).

Since we are using ome-types to parse xml, the current bottleneck to writing images is parsing the `OME` model to XML. Estimates suggest this could be an order of magnitude slower or more than actually compressing and saving the data to disk. We opened an issue on ome-types, suggesting creation of an option to use `lxml` to dump the data to string.

https://github.com/tlambert03/ome-types/tree/main/src/ome_types