### PR TITLE
CI: added action to test all tools

### DIFF
--- a/.github/workflows/test_tools.yml
+++ b/.github/workflows/test_tools.yml
@@ -1,0 +1,233 @@
+name: Test Image/Tabular/MM Tools
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches-ignore:
+      - master
+
+jobs:
+  build_wheels:
+    name: Build Wheels
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v4
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+      - name: Install build tools
+        run: |
+          python -m pip install twine build
+      - name: Build wheels
+        run: |
+          python -m build
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels
+          path: dist/*.whl
+          retention-days: 1
+  
+  find_image_tools:
+    needs: build_wheels
+    name: Find Image Tools
+    uses: polusai/image-tools/.github/workflows/find-all-tools.yml@master
+
+  pre-image-tests:
+    name: Pre-Update Image Tools | ${{ matrix.tool_name }}
+    runs-on: ubuntu-latest
+    needs: find_image_tools
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.find_image_tools.outputs.matrix) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          repository: 'nishaq503/image-tools'
+          ref: 'ci/find-all-tools'
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+      - name: Install Poetry
+        uses: abatilo/actions-poetry@v3
+      - name: Install | ${{ matrix.tool_name }}
+        run: |
+          cd ${{ matrix.tool_dir }}
+          poetry install
+      - name: Tests
+        run: |
+          cd ${{ matrix.tool_dir }}
+          poetry run pytest -v
+
+  post_image_tests:
+    name: Post-Update Image Tools | ${{ matrix.tool_name }}
+    runs-on: ubuntu-latest
+    needs: find_image_tools
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.find_image_tools.outputs.matrix) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          repository: 'nishaq503/image-tools'
+          ref: 'ci/find-all-tools'
+      - name: Install | Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+      - name: Install | Poetry
+        uses: abatilo/actions-poetry@v3
+      - name: Download Wheels
+        uses: actions/download-artifact@v4
+        with:
+          name: wheels
+          path: dist
+      - name: Install | ${{ matrix.tool_name }}
+        run: |
+          root_dir=$(pwd)
+          cd ${{ matrix.tool_dir }}
+          poetry install && pip install --find-links=${root_dir}/dist bfio
+      - name: Tests
+        run: |
+          cd ${{ matrix.tool_dir }}
+          poetry run pytest -v
+  
+  find_tabular_tools:
+    needs: build_wheels
+    name: Find Tabular Tools
+    uses: polusai/tabular-tools/.github/workflows/find-all-tools.yml@main
+
+  pre-tabular-tests:
+    name: Pre-Update Tabular Tools | ${{ matrix.tool_name }}
+    runs-on: ubuntu-latest
+    needs: find_tabular_tools
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.find_tabular_tools.outputs.matrix) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          repository: 'nishaq503/tabular-tools'
+          ref: 'ci/find-all-tools'
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+      - name: Install Poetry
+        uses: abatilo/actions-poetry@v3
+      - name: Install | ${{ matrix.tool_name }}
+        run: |
+          cd ${{ matrix.tool_dir }}
+          poetry install
+      - name: Tests
+        run: |
+          cd ${{ matrix.tool_dir }}
+          poetry run pytest -v
+
+  post_tabular_tests:
+    name: Post-Update Tabular Tools | ${{ matrix.tool_name }}
+    runs-on: ubuntu-latest
+    needs: find_tabular_tools
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.find_tabular_tools.outputs.matrix) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          repository: 'nishaq503/tabular-tools'
+          ref: 'ci/find-all-tools'
+      - name: Install | Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+      - name: Install | Poetry
+        uses: abatilo/actions-poetry@v3
+      - name: Download Wheels
+        uses: actions/download-artifact@v4
+        with:
+          name: wheels
+          path: dist
+      - name: Install | ${{ matrix.tool_name }}
+        run: |
+          root_dir=$(pwd)
+          cd ${{ matrix.tool_dir }}
+          poetry install && pip install --find-links=${root_dir}/dist bfio
+      - name: Tests
+        run: |
+          cd ${{ matrix.tool_dir }}
+          poetry run pytest -v
+  
+  find_mm_tools:
+    needs: build_wheels
+    name: Find MM Tools
+    uses: polusai/mm-tools/.github/workflows/find-all-tools.yml@main
+
+  pre-mm-tests:
+    name: Pre-Update MM Tools | ${{ matrix.tool_name }}
+    runs-on: ubuntu-latest
+    needs: find_mm_tools
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.find_mm_tools.outputs.matrix) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          repository: 'nishaq503/mm-tools'
+          ref: 'ci/find-all-tools'
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+      - name: Install Poetry
+        uses: abatilo/actions-poetry@v3
+      - name: Install | ${{ matrix.tool_name }}
+        run: |
+          cd ${{ matrix.tool_dir }}
+          poetry install
+      - name: Tests
+        run: |
+          cd ${{ matrix.tool_dir }}
+          poetry run pytest -v
+
+  post_mm_tests:
+    name: Post-Update MM Tools | ${{ matrix.tool_name }}
+    runs-on: ubuntu-latest
+    needs: find_mm_tools
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.find_mm_tools.outputs.matrix) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          repository: 'nishaq503/mm-tools'
+          ref: 'ci/find-all-tools'
+      - name: Install | Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+      - name: Install | Poetry
+        uses: abatilo/actions-poetry@v3
+      - name: Download Wheels
+        uses: actions/download-artifact@v4
+        with:
+          name: wheels
+          path: dist
+      - name: Install | ${{ matrix.tool_name }}
+        run: |
+          root_dir=$(pwd)
+          cd ${{ matrix.tool_dir }}
+          poetry install && pip install --find-links=${root_dir}/dist bfio
+      - name: Tests
+        run: |
+          cd ${{ matrix.tool_dir }}
+          poetry run pytest -v


### PR DESCRIPTION
This new action tests all tools in the `image-tools`, `tabular-tools` and `mm-tools` repositories. This PR is currently blocked on:

 - [x] making `mm-tools` into a public repository so that GitHub actions can be shared.
 - [x] merging accompanying PRs in the three repositories for the actions being reused here.