### PR TITLE
CI: added action for testing *-tools

### DIFF
--- a/.github/workflows/test_tools.yml
+++ b/.github/workflows/test_tools.yml
@@ -1,0 +1,267 @@
+name: Test Image/Tabular/MM Tools
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches-ignore:
+      - master
+
+jobs:
+  build_wheels:
+    name: Build Wheels
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v4
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+      - name: Install build tools
+        run: |
+          python -m pip install twine build
+      - name: Build wheels
+        run: |
+          python -m build
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels
+          path: dist/*.whl
+          retention-days: 1
+  
+  find_image_tools:
+    needs: build_wheels
+    name: Find Image Tools
+    uses: PolusAI/image-tools/.github/workflows/find-all-tools.yml@master
+
+  image-tests:
+    name: Images | ${{ matrix.tool_name }}
+    runs-on: ubuntu-latest
+    needs: find_image_tools
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.find_image_tools.outputs.matrix) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          repository: 'PolusAI/image-tools'
+          ref: "master"
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+      - name: Conda | Install
+        uses: conda-incubator/setup-miniconda@v3
+      - name: Poetry | Install
+        uses: abatilo/actions-poetry@v3
+      - name: Poetry | Config
+        run: |
+          poetry config virtualenvs.create false
+      - name: Tests | Pre-Update
+        run: |
+          # We see seg-faults during the cleanup phase of running test on the imagej tools.
+          set -e
+          trap 'case $? in
+            139) echo "::warning::Seg-fault detected in ${{ matrix.tool_name }}. Please check the logs for more information." && exit 0;;
+          esac' ERR
+
+          cd ${{ matrix.tool_dir }}
+
+          if [ -f "environment.yml" ]; then
+            conda init bash
+            source ~/.bashrc
+            conda env create -f environment.yml
+            conda activate project_env
+            pip install -e ".[all]"
+            conda install pytest
+            python -m pytest -v
+          else
+            poetry install
+            poetry run pytest -v
+          fi
+      - name: Download Wheels
+        uses: actions/download-artifact@v4
+        with:
+          name: wheels
+          path: dist
+      - name: Tests | Post-Update
+        run: |
+          set -e
+          trap 'case $? in
+            139) echo "::warning::Seg-fault detected in ${{ matrix.tool_name }}. Please check the logs for more information." && exit 0;;
+          esac' ERR
+
+          cd ${{ matrix.tool_dir }}
+          
+          if [ -f "environment.yml" ]; then
+            conda init bash
+            source ~/.bashrc
+            conda activate project_env
+            pip install -e ".[all]"
+            pip install --find-links=${root_dir}/dist bfio
+            conda install pytest
+            python -m pytest -v
+          else
+            poetry install
+            pip install --find-links=${root_dir}/dist bfio
+            poetry run pytest -v
+          fi
+  
+  find_tabular_tools:
+    needs: build_wheels
+    name: Find Tabular Tools
+    uses: PolusAI/tabular-tools/.github/workflows/find-all-tools.yml@main
+
+  tabular-tests:
+    name: Tabular | ${{ matrix.tool_name }}
+    runs-on: ubuntu-latest
+    needs: find_tabular_tools
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.find_tabular_tools.outputs.matrix) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          repository: 'PolusAI/tabular-tools'
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+      - name: Conda | Install
+        uses: conda-incubator/setup-miniconda@v3
+      - name: Poetry | Install
+        uses: abatilo/actions-poetry@v3
+      - name: Poetry | Config
+        run: |
+          poetry config virtualenvs.create false
+      - name: Tests | Pre-Update
+        run: |
+          set -e
+          trap 'case $? in
+            139) echo "::warning::Seg-fault detected in ${{ matrix.tool_name }}. Please check the logs for more information." && exit 0;;
+          esac' ERR
+
+          cd ${{ matrix.tool_dir }}
+
+          if [ -f "environment.yml" ]; then
+            conda init bash
+            source ~/.bashrc
+            conda env create -f environment.yml
+            conda activate project_env
+            pip install -e ".[all]"
+            conda install pytest
+            python -m pytest -v
+          else
+            poetry install
+            poetry run pytest -v
+          fi
+      - name: Download Wheels
+        uses: actions/download-artifact@v4
+        with:
+          name: wheels
+          path: dist
+      - name: Tests | Post-Update
+        run: |
+          set -e
+          trap 'case $? in
+            139) echo "::warning::Seg-fault detected in ${{ matrix.tool_name }}. Please check the logs for more information." && exit 0;;
+          esac' ERR
+
+          cd ${{ matrix.tool_dir }}
+          
+          if [ -f "environment.yml" ]; then
+            conda init bash
+            source ~/.bashrc
+            conda activate project_env
+            pip install -e ".[all]"
+            pip install --find-links=${root_dir}/dist bfio
+            conda install pytest
+            python -m pytest -v
+          else
+            poetry install
+            pip install --find-links=${root_dir}/dist bfio
+            poetry run pytest -v
+          fi
+  
+  # TODO: Uncomment tests for mm-tools after the pip package for `cwl_utilities`
+  #       is available on PyPI and the PRs on mm-tools are merged.
+  # find_mm_tools:
+  #   needs: build_wheels
+  #   name: Find MM Tools
+  #   uses: PolusAI/mm-tools/.github/workflows/find-all-tools.yml@main
+
+  # mm-tests:
+  #   name: MM | ${{ matrix.tool_name }}
+  #   runs-on: ubuntu-latest
+  #   needs: find_mm_tools
+  #   strategy:
+  #     fail-fast: false
+  #     matrix: ${{ fromJson(needs.find_mm_tools.outputs.matrix) }}
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v4
+  #       with:
+  #         repository: 'PolusAI/mm-tools'
+  #     - name: Set up Python 3.9
+  #       uses: actions/setup-python@v5
+  #       with:
+  #         python-version: '3.9'
+  #     - name: Conda | Install
+  #       uses: conda-incubator/setup-miniconda@v3
+  #     - name: Poetry | Install
+  #       uses: abatilo/actions-poetry@v3
+  #     - name: Poetry | Config
+  #       run: |
+  #         poetry config virtualenvs.create false
+  #     - name: Tests | Pre-Update
+  #       run: |
+  #         set -e
+  #         trap 'case $? in
+  #           139) echo "::warning::Seg-fault detected in ${{ matrix.tool_name }}. Please check the logs for more information." && exit 0;;
+  #         esac' ERR
+
+  #         cd ${{ matrix.tool_dir }}
+
+  #         if [ -f "environment.yml" ]; then
+  #           conda init bash
+  #           source ~/.bashrc
+  #           conda env create -f environment.yml
+  #           conda activate project_env
+  #           pip install -e ".[all]"
+  #           conda install pytest
+  #           python -m pytest -v
+  #         else
+  #           poetry install
+  #           poetry run pytest -v
+  #         fi
+  #     - name: Download Wheels
+  #       uses: actions/download-artifact@v4
+  #       with:
+  #         name: wheels
+  #         path: dist
+  #     - name: Tests | Post-Update
+  #       run: |
+  #         set -e
+  #         trap 'case $? in
+  #           139) echo "::warning::Seg-fault detected in ${{ matrix.tool_name }}. Please check the logs for more information." && exit 0;;
+  #         esac' ERR
+
+  #         cd ${{ matrix.tool_dir }}
+          
+  #         if [ -f "environment.yml" ]; then
+  #           conda init bash
+  #           source ~/.bashrc
+  #           conda activate project_env
+  #           pip install -e ".[all]"
+  #           pip install --find-links=${root_dir}/dist bfio
+  #           conda install pytest
+  #           python -m pytest -v
+  #         else
+  #           poetry install
+  #           pip install --find-links=${root_dir}/dist bfio
+  #           poetry run pytest -v
+  #         fi


### PR DESCRIPTION
- For mm-tools, we are still waiting on a pip-package for `cwl_utilities`. Until then the relevant jobs have been commented out.
- Most of the tools using imagej produce a seg-fault during cleanup after running all tests. I explicitly catch seg-faults and raise warnings for them in the github action.